### PR TITLE
Add Solidity language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A few things that set it apart:
 
 - **Dual line counts** - Total lines and effective lines (excluding comments and blanks) per language. Use `--with-spaces` to base summaries and percentages on total lines instead
 - **Six categories** - Code, DevOps, Design, Docs, Specs, and Data, each with aggregated totals
-- **40 languages** - From Python and Rust to Terraform and Docker, with full template support for HTML (Jinja, Nunjucks, Handlebars, and more)
+- **41 languages** - From Python and Rust to Solidity, Terraform, and Docker, with full template support for HTML (Jinja, Nunjucks, Handlebars, and more)
 - **Beautiful output** - Colored, formatted results with a language composition bar, powered by [Rich](https://github.com/Textualize/rich)
 - **Realistic metrics** - Only counts files *you* wrote, not third-party dependencies or generated code
 - **Persistent config** - Your setup choices are saved to `.tally-config.toml` and reused on every run
@@ -75,11 +75,11 @@ The card includes category totals with effective line counts, a colored language
 
 ## Supported Languages
 
-Tallyman recognizes **40 languages** across six categories:
+Tallyman recognizes **41 languages** across six categories:
 
 | Category | Languages |
 |----------|-----------|
-| **Code** | Python, Rust, Go, JavaScript, TypeScript, Java, C, C++, C#, Swift, Kotlin, Ruby, Shell, Lua, PHP, Perl, R, Dart, Scala, Elixir, Zig, Haskell, Erlang, OCaml, Nim, V |
+| **Code** | Python, Rust, Go, JavaScript, TypeScript, Java, C, C++, C#, Swift, Kotlin, Ruby, Shell, Lua, PHP, Perl, R, Dart, Scala, Elixir, Zig, Haskell, Erlang, OCaml, Nim, V, Solidity |
 | **DevOps** | Terraform, Makefile, Docker |
 | **Design** | CSS, SCSS, LESS, HTML (+ 12 template formats), SVG |
 | **Docs** | Markdown, reStructuredText |
@@ -120,6 +120,7 @@ Tallyman recognizes **40 languages** across six categories:
 | OCaml | `.ml`, `.mli` |
 | Nim | `.nim`, `.nims` |
 | V | `.v`, `.vv` |
+| Solidity | `.sol` |
 
 ### DevOps
 

--- a/change-log.md
+++ b/change-log.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### Added
+- Solidity language support for `.sol` files, counted as Code with `//` single-line comment detection.
+- Files: `src/tallyman/languages.py`, `tests/test_languages.py`, `tests/test_counter.py`, `tests/test_walker.py`, `README.md`
 - `--with-spaces` flag: use total lines (including comments and blanks) for category totals, combined total, percentage bar, and legend. Applies to both terminal output and PNG image export. Default behavior (effective lines) is unchanged.
 - Percentage bar and legend now use effective lines by default, consistent with the category totals shown above them (previously always used total lines).
 - Files: `src/tallyman/cli.py`, `src/tallyman/display.py`, `src/tallyman/image.py`, `src/tallyman/aggregator.py`, `tests/test_aggregator.py`

--- a/src/tallyman/languages.py
+++ b/src/tallyman/languages.py
@@ -46,6 +46,7 @@ LANGUAGES: tuple[Language, ...] = (
     Language('OCaml',        'code',   'sandy_brown',     None, ('.ml', '.mli')),
     Language('Nim',          'code',   'gold3',           '#',  ('.nim', '.nims')),
     Language('V',            'code',   'sky_blue1',       '//', ('.v', '.vv')),
+    Language('Solidity',     'code',   'bright_cyan',     '//', ('.sol',)),
     # --- DevOps ---
     Language('Terraform',    'devops', 'purple4',         '#',  ('.tf', '.tfvars')),
     Language('Makefile',     'devops', 'bright_white',    '#',  ('.mk',)),

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -30,6 +30,15 @@ class TestCountLines:
         assert result.blank_lines == 1
         assert result.code_lines == 1
 
+    def test_solidity_style_comments(self, tmp_path: Path):
+        f = tmp_path / 'Token.sol'
+        f.write_text('// SPDX-License-Identifier: MIT\ncontract Token {\n    // storage\n    uint256 totalSupply;\n}\n')
+        result = count_lines(f, _lang('//'))
+        assert result.total_lines == 5
+        assert result.comment_lines == 2
+        assert result.blank_lines == 0
+        assert result.code_lines == 3
+
     def test_dash_comments(self, tmp_path: Path):
         f = tmp_path / 'example.lua'
         f.write_text('-- comment\nprint("hi")\n')

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -26,6 +26,13 @@ class TestIdentifyLanguage:
         assert lang is not None
         assert lang.name == 'TypeScript'
 
+    def test_solidity_file(self):
+        lang = identify_language(Path('Token.sol'))
+        assert lang is not None
+        assert lang.name == 'Solidity'
+        assert lang.category == 'code'
+        assert lang.single_line_comment == '//'
+
     def test_markdown(self):
         lang = identify_language(Path('README.md'))
         assert lang is not None

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -113,6 +113,17 @@ class TestWalkProject:
         paths = {r[0].name for r in results}
         assert 'LICENSE' not in paths
 
+    def test_yields_solidity_files(self, tmp_path: Path):
+        root = self._setup_project(tmp_path)
+        contracts = root / 'contracts'
+        contracts.mkdir()
+        (contracts / 'Token.sol').write_text('contract Token {}\n')
+
+        results = list(walk_project(root, set()))
+        solidity_lang = next(lang for path, lang in results if path.name == 'Token.sol')
+        assert solidity_lang.name == 'Solidity'
+        assert solidity_lang.category == 'code'
+
     def test_respects_excluded_dirs(self, tmp_path: Path):
         root = self._setup_project(tmp_path)
         results = list(walk_project(root, {'src'}))


### PR DESCRIPTION
Adds Solidity .sol file support to Tallyman.

Solidity files are categorized as Code and use the existing // single-line comment detection behavior. This updates the supported language documentation and adds tests for language detection, line counting, and project traversal.